### PR TITLE
ElasticSEarch 7.9.1 support

### DIFF
--- a/experimental-highlighter-core/pom.xml
+++ b/experimental-highlighter-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.wikimedia.search.highlighter</groupId>
         <artifactId>experimental</artifactId>
-        <version>7.5.2-SNAPSHOT</version>
+        <version>7.9.1-SNAPSHOT</version>
     </parent>
     <artifactId>experimental-highlighter-core</artifactId>
     <packaging>jar</packaging>

--- a/experimental-highlighter-elasticsearch-plugin/pom.xml
+++ b/experimental-highlighter-elasticsearch-plugin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.wikimedia.search.highlighter</groupId>
         <artifactId>experimental</artifactId>
-        <version>7.5.2-SNAPSHOT</version>
+        <version>7.9.1-SNAPSHOT</version>
     </parent>
     <artifactId>experimental-highlighter-elasticsearch-plugin</artifactId>
     <packaging>jar</packaging>

--- a/experimental-highlighter-elasticsearch-plugin/src/test/java/org/wikimedia/highlighter/experimental/elasticsearch/AbstractExperimentalHighlighterIntegrationTestBase.java
+++ b/experimental-highlighter-elasticsearch-plugin/src/test/java/org/wikimedia/highlighter/experimental/elasticsearch/AbstractExperimentalHighlighterIntegrationTestBase.java
@@ -578,8 +578,8 @@ ESIntegTestCase {
                 if (!Booleans.isBoolean(value)) {
                     @SuppressWarnings("deprecation")
                     boolean convertedValue = Booleans.parseBooleanLenient(settings.get(PRESERVE_ORIGINAL.getPreferredName()), DEFAULT_PRESERVE_ORIGINAL);
-                    deprecationLogger.deprecated("The value [{}] of setting [{}] is not coerced into boolean anymore. Please change " +
-                            "this value to [{}].", value, PRESERVE_ORIGINAL.getPreferredName(), String.valueOf(convertedValue));
+                    deprecationLogger.deprecatedAndMaybeLog("value_not_coerced_bool", "The value [{}] of setting [{}] is not coerced into boolean anymore. " +
+                             "Please change this value to [{}].", value, PRESERVE_ORIGINAL.getPreferredName(), String.valueOf(convertedValue));
                     preserveOriginal =  convertedValue;
                 } else {
                     preserveOriginal = settings.getAsBoolean(PRESERVE_ORIGINAL.getPreferredName(), DEFAULT_PRESERVE_ORIGINAL);

--- a/experimental-highlighter-lucene/pom.xml
+++ b/experimental-highlighter-lucene/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.wikimedia.search.highlighter</groupId>
         <artifactId>experimental</artifactId>
-        <version>7.5.2-SNAPSHOT</version>
+        <version>7.9.1-SNAPSHOT</version>
     </parent>
     <artifactId>experimental-highlighter-lucene</artifactId>
     <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>org.wikimedia.search.highlighter</groupId>
     <artifactId>experimental</artifactId>
-    <version>7.5.2-SNAPSHOT</version>
+    <version>7.9.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Elasticsearch experimental highlighter plugin</name>
@@ -43,7 +43,7 @@
     <scm>
         <connection>scm:git:https://gerrit.wikimedia.org/r/search/highlighter</connection>
         <developerConnection>scm:git:ssh://gerrit.wikimedia.org:29418/search/highlighter</developerConnection>
-        <tag>HEAD</tag>
+        <tag>experimental-7.9.1</tag>
         <url>https://gerrit.wikimedia.org/r/#/admin/projects/search/highlighter</url>
     </scm>
 
@@ -53,12 +53,12 @@
     </issueManagement>
 
     <properties>
-        <elasticsearch.version>7.5.1</elasticsearch.version>
-        <log4j.version>2.11.1</log4j.version>
+        <elasticsearch.version>7.9.1</elasticsearch.version>
+        <log4j.version>2.17.1</log4j.version>
         <!-- For the Elasticsearch plugin to work this should match the version of Lucene that Elasticsearch
       uses. -->
-        <lucene.version>8.3.0</lucene.version>
-        <randomizedtesting.version>2.7.0</randomizedtesting.version>
+        <lucene.version>8.6.2</lucene.version>
+        <randomizedtesting.version>2.7.1</randomizedtesting.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
The latest ES version 7.10.2 that this plugin supports wasn't compatible with ES version 7.9.1 I was using, so contributing fixes for it into a new branch.

There is no need to merge this into a master, but would be great if someone could create a branch 7.9.1 (based on [afe958a commit](https://github.com/nikitiuk0/search-highlighter/commit/afe958a6f31bb2be17161b1d484470061c6530a7)) and merge my changes into that branch. Please let me know if you I could help with that in any way.